### PR TITLE
Automatically detect the Python to use.

### DIFF
--- a/add_new_brand.sh
+++ b/add_new_brand.sh
@@ -10,7 +10,7 @@ if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi
 
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt

--- a/add_new_brand.sh
+++ b/add_new_brand.sh
@@ -6,11 +6,13 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-rm -rf $HOME/.local/ubersmith_venv
-
 # Requires python3-venv on Ubuntu
-echo "Creating Ubersmith Python virtual environment..."
-python3 -m venv $HOME/.local/ubersmith_venv
+if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
+    source ./find_python.sh
+
+    echo "Creating Ubersmith Python virtual environment..."
+    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
+fi
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/add_new_brand.sh
+++ b/add_new_brand.sh
@@ -9,9 +9,6 @@ export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 # Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
-
-    echo "Creating Ubersmith Python virtual environment..."
-    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 fi
 
 source $HOME/.local/ubersmith_venv/bin/activate

--- a/add_new_brand.sh
+++ b/add_new_brand.sh
@@ -6,7 +6,6 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-# Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi

--- a/configure.sh
+++ b/configure.sh
@@ -5,8 +5,10 @@ export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
 # Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
+    source ./find_python.sh
+
     echo "Creating Ubersmith Python virtual environment..."
-    python3 -m venv $HOME/.local/ubersmith_venv
+    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 fi
 
 source $HOME/.local/ubersmith_venv/bin/activate

--- a/configure.sh
+++ b/configure.sh
@@ -7,7 +7,7 @@ if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi
 
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt

--- a/configure.sh
+++ b/configure.sh
@@ -3,7 +3,6 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-# Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi

--- a/configure.sh
+++ b/configure.sh
@@ -6,9 +6,6 @@ export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 # Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
-
-    echo "Creating Ubersmith Python virtual environment..."
-    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 fi
 
 source $HOME/.local/ubersmith_venv/bin/activate

--- a/find_python.sh
+++ b/find_python.sh
@@ -5,7 +5,7 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-rm -rf $HOME/.local/ubersmith_venv
+rm -rf "$HOME"/.local/ubersmith_venv
 
 echo "Checking for Python 3.11 or newer..."
 
@@ -31,4 +31,4 @@ echo "Using $PYTHON_BIN ($NEWEST_VERSION)"
 
 # Requires python3-venv on Ubuntu
 echo "Creating Ubersmith Python virtual environment..."
-"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
+"$PYTHON_BIN" -m venv "$HOME"/.local/ubersmith_venv

--- a/find_python.sh
+++ b/find_python.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+# Find the newest Python to use
+
+export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
+
+rm -rf $HOME/.local/ubersmith_venv
+
+echo "Checking for Python 3.11 or newer..."
+
+PYTHON_BIN=""
+NEWEST_VERSION=""
+
+for pybin in $(compgen -c python3 | grep -E '^python3(\.[0-9]+)?$' | sort -u); do
+    command -v "$pybin" &> /dev/null || continue
+    "$pybin" -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null || continue
+    VERSION=$("$pybin" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
+    if [ -z "$NEWEST_VERSION" ] || [ "$(printf '%s\n' "$NEWEST_VERSION" "$VERSION" | sort -V | tail -n1)" = "$VERSION" ]; then
+        NEWEST_VERSION=$VERSION
+        PYTHON_BIN=$pybin
+    fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
+    echo "Error: no Python 3.11 or newer found in your PATH. Please install Python 3.11+ and try again."
+    exit 1
+fi
+
+echo "Using $PYTHON_BIN ($NEWEST_VERSION)"

--- a/find_python.sh
+++ b/find_python.sh
@@ -28,3 +28,7 @@ if [ -z "$PYTHON_BIN" ]; then
 fi
 
 echo "Using $PYTHON_BIN ($NEWEST_VERSION)"
+
+# Requires python3-venv on Ubuntu
+echo "Creating Ubersmith Python virtual environment..."
+"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv

--- a/install_appliance.sh
+++ b/install_appliance.sh
@@ -4,32 +4,11 @@ set -e
 # SSL and Python development libraries are required.
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
-export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
-
-rm -rf $HOME/.local/ubersmith_venv
-
-echo "Checking for Python 3.11 or newer..."
-
-# Check if python3 command exists
-if ! command -v python3 &> /dev/null; then
-    echo "Error: The python3 binary is not installed or not in your PATH. Please check the Installation Documentation."
-    exit 1
-fi
-
-# Use a short Python script to check its own version.
-# sys.version_info is a tuple like (3, 11, 4, ...)
-if python3 -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-    # echo "OK: Python version $VERSION is 3.11 or newer."
-else
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || echo "unknown")
-    echo "Error: Python version ($VERSION) is older than 3.11. Please upgrade your Python installation."
-    exit 1
-fi
+source ./find_python.sh
 
 # Requires python3-venv on Ubuntu
 echo "Creating Ubersmith Python virtual environment..."
-python3 -m venv $HOME/.local/ubersmith_venv
+"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/install_appliance.sh
+++ b/install_appliance.sh
@@ -5,7 +5,7 @@ set -e
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
 source ./find_python.sh
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt

--- a/install_appliance.sh
+++ b/install_appliance.sh
@@ -5,11 +5,6 @@ set -e
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
 source ./find_python.sh
-
-# Requires python3-venv on Ubuntu
-echo "Creating Ubersmith Python virtual environment..."
-"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
-
 source $HOME/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."

--- a/install_ubersmith.sh
+++ b/install_ubersmith.sh
@@ -5,7 +5,7 @@ set -e
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
 source ./find_python.sh
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt

--- a/install_ubersmith.sh
+++ b/install_ubersmith.sh
@@ -5,11 +5,6 @@ set -e
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
 source ./find_python.sh
-
-# Requires python3-venv on Ubuntu
-echo "Creating Ubersmith Python virtual environment..."
-"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
-
 source $HOME/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."

--- a/install_ubersmith.sh
+++ b/install_ubersmith.sh
@@ -4,32 +4,11 @@ set -e
 # SSL and Python development libraries are required.
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
-export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
-
-rm -rf $HOME/.local/ubersmith_venv
-
-echo "Checking for Python 3.11 or newer..."
-
-# Check if python3 command exists
-if ! command -v python3 &> /dev/null; then
-    echo "Error: python3 is not installed or not in your PATH. Please check the Installation "
-    exit 1
-fi
-
-# Use a short Python script to check its own version.
-# sys.version_info is a tuple like (3, 11, 4, ...)
-if python3 -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-    # echo "OK: Python version $VERSION is 3.11 or newer."
-else
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || echo "unknown")
-    echo "Error: Python version ($VERSION) is older than 3.11. Please upgrade your Python installation."
-    exit 1
-fi
+source ./find_python.sh
 
 # Requires python3-venv on Ubuntu
 echo "Creating Ubersmith Python virtual environment..."
-python3 -m venv $HOME/.local/ubersmith_venv
+"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/patch_ubersmith.sh
+++ b/patch_ubersmith.sh
@@ -10,7 +10,7 @@ if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi
 
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt

--- a/patch_ubersmith.sh
+++ b/patch_ubersmith.sh
@@ -4,32 +4,11 @@ set -e
 # SSL and Python development libraries are required.
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
-export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
-
-rm -rf $HOME/.local/ubersmith_venv
-
-echo "Checking for Python 3.11 or newer..."
-
-# Check if python3 command exists
-if ! command -v python3 &> /dev/null; then
-    echo "Error: python3 is not installed or not in your PATH. Please check the Installation "
-    exit 1
-fi
-
-# Use a short Python script to check its own version.
-# sys.version_info is a tuple like (3, 11, 4, ...)
-if python3 -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-    # echo "OK: Python version $VERSION is 3.11 or newer."
-else
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || echo "unknown")
-    echo "Error: Python version ($VERSION) is older than 3.11. Please upgrade your Python installation."
-    exit 1
-fi
+source ./find_python.sh
 
 # Requires python3-venv on Ubuntu
 echo "Creating Ubersmith Python virtual environment..."
-python3 -m venv $HOME/.local/ubersmith_venv
+"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/patch_ubersmith.sh
+++ b/patch_ubersmith.sh
@@ -4,11 +4,12 @@ set -e
 # SSL and Python development libraries are required.
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
-source ./find_python.sh
+export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
 # Requires python3-venv on Ubuntu
-echo "Creating Ubersmith Python virtual environment..."
-"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
+if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
+    source ./find_python.sh
+fi
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/patch_ubersmith.sh
+++ b/patch_ubersmith.sh
@@ -6,7 +6,6 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-# Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi

--- a/remove_patches.sh
+++ b/remove_patches.sh
@@ -10,7 +10,7 @@ if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi
 
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt

--- a/remove_patches.sh
+++ b/remove_patches.sh
@@ -6,11 +6,13 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-rm -rf $HOME/.local/ubersmith_venv
-
 # Requires python3-venv on Ubuntu
-echo "Creating Ubersmith Python virtual environment..."
-python3 -m venv $HOME/.local/ubersmith_venv
+if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
+    source ./find_python.sh
+
+    echo "Creating Ubersmith Python virtual environment..."
+    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
+fi
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/remove_patches.sh
+++ b/remove_patches.sh
@@ -9,9 +9,6 @@ export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 # Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
-
-    echo "Creating Ubersmith Python virtual environment..."
-    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 fi
 
 source $HOME/.local/ubersmith_venv/bin/activate

--- a/remove_patches.sh
+++ b/remove_patches.sh
@@ -6,7 +6,6 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-# Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi

--- a/retry_letsencrypt.sh
+++ b/retry_letsencrypt.sh
@@ -10,7 +10,7 @@ if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi
 
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Retrying Let's Encrypt certificate request..."
 ansible-playbook -i ./hosts -e ansible_python_interpreter=$(which python3) -c local retry_letsencrypt.yml

--- a/retry_letsencrypt.sh
+++ b/retry_letsencrypt.sh
@@ -9,9 +9,6 @@ export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 # Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
-
-    echo "Creating Ubersmith Python virtual environment..."
-    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 fi
 
 source $HOME/.local/ubersmith_venv/bin/activate

--- a/retry_letsencrypt.sh
+++ b/retry_letsencrypt.sh
@@ -6,6 +6,14 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
+# Requires python3-venv on Ubuntu
+if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
+    source ./find_python.sh
+
+    echo "Creating Ubersmith Python virtual environment..."
+    "$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
+fi
+
 source $HOME/.local/ubersmith_venv/bin/activate
 
 echo "Retrying Let's Encrypt certificate request..."

--- a/retry_letsencrypt.sh
+++ b/retry_letsencrypt.sh
@@ -6,7 +6,6 @@ set -e
 
 export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
 
-# Requires python3-venv on Ubuntu
 if [ ! -d "$HOME/.local/ubersmith_venv" ]; then
     source ./find_python.sh
 fi

--- a/upgrade_appliance.sh
+++ b/upgrade_appliance.sh
@@ -4,32 +4,11 @@ set -e
 # SSL and Python development libraries are required.
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
-export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
-
-rm -rf $HOME/.local/ubersmith_venv
-
-echo "Checking for Python 3.11 or newer..."
-
-# Check if python3 command exists
-if ! command -v python3 &> /dev/null; then
-    echo "Error: The python3 binary is not installed or not in your PATH. Please check the Installation Documentation."
-    exit 1
-fi
-
-# Use a short Python script to check its own version.
-# sys.version_info is a tuple like (3, 11, 4, ...)
-if python3 -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-    # echo "OK: Python version $VERSION is 3.11 or newer."
-else
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || echo "unknown")
-    echo "Error: Python version ($VERSION) is older than 3.11. Please upgrade your Python installation."
-    exit 1
-fi
+source ./find_python.sh
 
 # Requires python3-venv on Ubuntu
 echo "Creating Ubersmith Python virtual environment..."
-python3 -m venv $HOME/.local/ubersmith_venv
+"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/upgrade_appliance.sh
+++ b/upgrade_appliance.sh
@@ -5,7 +5,7 @@ set -e
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
 source ./find_python.sh
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt

--- a/upgrade_appliance.sh
+++ b/upgrade_appliance.sh
@@ -5,11 +5,6 @@ set -e
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
 source ./find_python.sh
-
-# Requires python3-venv on Ubuntu
-echo "Creating Ubersmith Python virtual environment..."
-"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
-
 source $HOME/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."

--- a/upgrade_ubersmith.sh
+++ b/upgrade_ubersmith.sh
@@ -4,38 +4,17 @@ set -e
 # SSL and Python development libraries are required.
 # See documentation at https://docs.ubersmith.com/article.php?id=231
 
-export PATH="$HOME/.local/bin:$HOME/.local/ubersmith_venv/bin:$PATH"
-
-rm -rf $HOME/.local/ubersmith_venv
-
-echo "Checking for Python 3.11 or newer..."
-
-# Check if python3 command exists
-if ! command -v python3 &> /dev/null; then
-    echo "Error: python3 is not installed or not in your PATH. Please install it and try again."
-    exit 1
-fi
-
 # Check if screen command exists
 if ! command -v screen &> /dev/null; then
     echo "Error: GNU screen is not installed. Please install it and try again."
     exit 1
 fi
 
-# Use a short Python script to check its own version.
-# sys.version_info is a tuple like (3, 11, 4, ...)
-if python3 -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-    # echo "OK: Python version $VERSION is 3.11 or newer."
-else
-    VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null || echo "unknown")
-    echo "Error: Python version ($VERSION) is older than 3.11. Please upgrade your Python installation."
-    exit 1
-fi
+source ./find_python.sh
 
 # Requires python3-venv on Ubuntu
 echo "Creating Ubersmith Python virtual environment..."
-python3 -m venv $HOME/.local/ubersmith_venv
+"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
 
 source $HOME/.local/ubersmith_venv/bin/activate
 

--- a/upgrade_ubersmith.sh
+++ b/upgrade_ubersmith.sh
@@ -11,11 +11,6 @@ if ! command -v screen &> /dev/null; then
 fi
 
 source ./find_python.sh
-
-# Requires python3-venv on Ubuntu
-echo "Creating Ubersmith Python virtual environment..."
-"$PYTHON_BIN" -m venv $HOME/.local/ubersmith_venv
-
 source $HOME/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."

--- a/upgrade_ubersmith.sh
+++ b/upgrade_ubersmith.sh
@@ -11,7 +11,7 @@ if ! command -v screen &> /dev/null; then
 fi
 
 source ./find_python.sh
-source $HOME/.local/ubersmith_venv/bin/activate
+source "$HOME"/.local/ubersmith_venv/bin/activate
 
 echo "Installing Dependencies..."
 pip3 install --disable-pip-version-check -q -r requirements_pip.txt


### PR DESCRIPTION
Using alternatives on Rocky/Alma to change the system default for Python is strongly discouraged as it can break a lot of tools. It's better if we just find the newest Python to use for our venv.